### PR TITLE
Update to CSET v25.5.0

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  python_min: "3.10"
-  version: "25.3.1"
+  python_min: "3.11"
+  version: "25.5.0"
 
 package:
   name: cset
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/c/cset/cset-${{ version }}.tar.gz
-  sha256: 5c8fcf379ecf4686930254a5d110f8df2ecff3278bbba67995ce84479e3cc574
+  sha256: c3b633347a248f14f7065de5b085c24219ccac4bc160d56e3e4168809a2123f1
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: "python -m pip install . --no-deps -vv"
   python:
@@ -35,6 +35,8 @@ requirements:
     - markdown-it-py >=3.0
     - nc-time-axis
     - iris-grib
+    # Dask pinned. See https://github.com/SciTools/iris/issues/6417
+    - dask ==2025.3.0
 
 tests:
   - python:


### PR DESCRIPTION
We pin dask due to its latest release being incompatible with iris. See https://github.com/SciTools/iris/issues/6417

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
