### PR TITLE
Unpin dask and bump minimum iris version to 3.12.2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c3b633347a248f14f7065de5b085c24219ccac4bc160d56e3e4168809a2123f1
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "python -m pip install . --no-deps -vv"
   python:
@@ -27,7 +27,7 @@ requirements:
   run:
     - python >=${{ python_min }}
     - numpy
-    - iris >=3.6
+    - iris >=3.12.2
     - ruamel.yaml >=0.17
     - pygraphviz >=1.11
     - mo_pack >=0.3
@@ -35,8 +35,6 @@ requirements:
     - markdown-it-py >=3.0
     - nc-time-axis
     - iris-grib
-    # Dask pinned. See https://github.com/SciTools/iris/issues/6417
-    - dask ==2025.3.0
 
 tests:
   - python:


### PR DESCRIPTION
This fixes the crashes with dask >= 2025.4.0. See https://github.com/SciTools/iris/issues/6417 for discussion.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
